### PR TITLE
Move the settings menu entry in the proper submenu

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -8,7 +8,7 @@
 					"caption": "Modelines",
 					"children": [
 						{
-							"caption": "Settings…",
+							"caption": "Settings",
 							"id": "modelines-settings",
 							"command": "edit_settings",
 							"args": {

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -2,18 +2,21 @@
 	"id": "preferences",
 	"children": [
 		{
-			"caption": "Package Settings",
-			"mnemonic": "P",
 			"id": "package-settings",
 			"children": [
 				{
 					"caption": "Modelines",
-					"id": "modelines-settings",
-					"command": "edit_settings",
-					"args": {
-						"base_file": "${packages}/Modelines/Modelines.sublime-settings",
-						"default": "/* See the left pane for the list of settings and valid values. */\n{\n\t$0\n}\n",
-					}
+					"children": [
+						{
+							"caption": "Settings…",
+							"id": "modelines-settings",
+							"command": "edit_settings",
+							"args": {
+								"base_file": "${packages}/Modelines/Modelines.sublime-settings",
+								"default": "/* See the left pane for the list of settings and valid values. */\n{\n\t$0\n}\n",
+							}
+						}
+					]
 				}
 			]
 		}


### PR DESCRIPTION
Note: I put an ellipsis to the `Settings…` menu entry. This is a common thing on macOS: menu entries that open a window should end with an ellipsis.

I can revert that particular change if needed.